### PR TITLE
[FEATURE] VoIP relaying on matrix homeserver with TURN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [v1.4.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v1.4.0)
+
+* Added CoTURN installation and integration
 
 ## [v1.3.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v1.3.0)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,11 @@
 
 # Our friendly and public domain name for the Synapse
 # server (the one that conforms user ID and room alias)
+# eg: my-organization.org (you would get @users:my-organization.org and #rooms:my-organization.org)
 synapse_server_name: "{{ inventory_hostname }}"
-# FQDN of the server that effectively hosting synapse
+
+# FQDN of the server that effectively hosting synapse (matrix endpoint)
+# eg: matrix.my-organization.org
 synapse_server_fqdn: "{{ inventory_hostname }}"
 
 # Location where synapse will be downloaded and installed from PyPI
@@ -84,7 +87,7 @@ synapse_turn_port: 5349  # TURN listener TCP&UDP port: 3478(default) 5349(for TL
 synapse_turn_shared_secret: 5Eydym68SovsZkYLT8G9TOSCFwc2E6ijVLwL4FQgbukKPUalQZOe5gj22E9EhYrm # change it and put it from a vault
 synapse_turn_user_lifetime: 86400000
 synapse_turn_allow_guests: True
-synapse_turn_denied_peer_ip: 
+synapse_turn_denied_peer_ip:
   - 10.0.0.0-10.255.255.255
   - 172.16.0.0-172.31.255.255
   - 192.168.0.0-192.168.255.255
@@ -103,6 +106,7 @@ synapse_installation_with_riot: false
 riot_installation_path: /var/www/riot
 
 # Our public domain name for the Riot Web client
+# eg: riot.my-organization.org
 riot_server_name: "{{ synapse_server_name }}"
 
 # Look https://github.com/vector-im/riot-web/releases to use the latest version

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,6 +74,27 @@ synapse_ldap_bind_password: ""
 
 
 #######################
+########  TURN  #######
+#######################
+
+synapse_with_turn: false
+synapse_turn_uri: "{{ synapse_server_fqdn }}"
+synapse_turn_port: 5349  # TURN listener TCP&UDP port: 3478(default) 5349(for TLS)
+
+synapse_turn_shared_secret: 5Eydym68SovsZkYLT8G9TOSCFwc2E6ijVLwL4FQgbukKPUalQZOe5gj22E9EhYrm # change it and put it from a vault
+synapse_turn_user_lifetime: 86400000
+synapse_turn_allow_guests: True
+synapse_turn_denied_peer_ip: 
+  - 10.0.0.0-10.255.255.255
+  - 172.16.0.0-172.31.255.255
+  - 192.168.0.0-192.168.255.255
+synapse_turn_allowed_peer_ip:
+    # The turn server itself (special case) so that client->TURN->TURN->client flows work
+  - "{{ ansible_default_ipv4.address if(ansible_default_ipv4.address) is defined else '' }}"
+  - "{{ ansible_default_ipv6.address if(ansible_default_ipv6.address) is defined else '' }}"
+
+
+#######################
 ########  Riot  #######
 #######################
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -11,6 +11,11 @@
     name: postfix
     state: restarted
 
+- name: restart coturn
+  service:
+    name: coturn
+    state: restarted
+
 - name: restart matrix-synapse
   service:
     name: matrix-synapse

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,6 +7,8 @@
 
 - include_tasks: ldap.yml
 
+- include_tasks: turn.yml
+
 - include_tasks: nginx_reverse_proxy.yml
 
 - include_tasks: postgresql.yml

--- a/tasks/turn.yml
+++ b/tasks/turn.yml
@@ -24,7 +24,7 @@
       denied-peer-ip={{ item }}
       {% endif %}
       {% endfor %}
-      
+
       {% for item in synapse_turn_allowed_peer_ip %}
       {% if(item is defined and item | length > 0) %}
       allowed-peer-ip={{ item }}

--- a/tasks/turn.yml
+++ b/tasks/turn.yml
@@ -1,0 +1,52 @@
+---
+
+# Based on https://github.com/matrix-org/synapse/blob/master/docs/turn-howto.md
+
+- name: "{{ 'Install' if(synapse_with_turn) else 'Unistall' }} CoTURN server"
+  apt:
+    name: coturn
+    state: "{{ 'present' if(synapse_with_turn) else 'absent' }}"
+    purge: "{{ omit if(synapse_with_turn) else true }}"
+
+- name: Configure CoTURN server
+  blockinfile:
+    path: /etc/turnserver.conf # By default, all directives in this file are commented
+    block: |
+      use-auth-secret
+      static-auth-secret={{ synapse_turn_shared_secret }}
+      realm={{ synapse_turn_uri }}
+      no-tcp-relay
+      user-quota=12
+      total-quota=1200
+
+      {% for item in synapse_turn_denied_peer_ip %}
+      {% if(item is defined and item | length > 0) %}
+      denied-peer-ip={{ item }}
+      {% endif %}
+      {% endfor %}
+      
+      {% for item in synapse_turn_allowed_peer_ip %}
+      {% if(item is defined and item | length > 0) %}
+      allowed-peer-ip={{ item }}
+      {% endif %}
+      {% endfor %}
+
+  notify: restart coturn
+  when: synapse_with_turn | bool
+
+- name: Enable TURN integration
+  template:
+    src: "{{ synapse_confd_templates_src }}/turn.yaml.j2"
+    dest: "{{ synapse_installation_path }}/conf.d/turn.yaml"
+    mode: 0644
+    owner: root
+    group: root
+  notify: restart matrix-synapse
+  when: synapse_with_turn | bool
+
+- name: Disable TURN integration
+  file:
+    path: "{{ synapse_installation_path }}/conf.d/turn.yaml"
+    state: absent
+  notify: restart matrix-synapse
+  when: not synapse_with_turn | bool

--- a/templates/var/lib/matrix-synapse/conf.d/turn.yaml.j2
+++ b/templates/var/lib/matrix-synapse/conf.d/turn.yaml.j2
@@ -1,0 +1,6 @@
+## TURN ##
+
+turn_uris: [ "turn:{{ synapse_turn_uri }}:{{ synapse_turn_port }}?transport=udp", "turn:{{ synapse_turn_uri }}:{{ synapse_turn_port }}?transport=tcp" ]
+turn_shared_secret: {{ synapse_turn_shared_secret }}
+turn_user_lifetime: {{ synapse_turn_user_lifetime }}
+turn_allow_guests: {{ synapse_turn_allow_guests }}


### PR DESCRIPTION
I open this PR for the review of provisioning a CoTURN installation to enable VoIP relaying on matrix homeserver with TURN. New feature to release in `v1.4.0`

