### PR TITLE
Good bye riot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [v3.0.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v3.0.0)
+
+* Version 2.0.0 of the role is not able to install Element web app from version 1.7.15. Since version 3.0.0, this role is compatible with [Element web app version 1.7.15](https://github.com/vector-im/element-web/releases/tag/v1.7.15) and above, but is not compatible with Riot/Element versions 1.7.14 and olders.
 
 ## [v2.0.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v2.0.0)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Through authentication providers it's possible to integrate decentralized logins
 
 Finally, this role also allows you to serve the [Element](https://app.element.io/) (formerly Riot) web application together with Synapse. This feature is disabled by default (`synapse_installation_with_element: false`) due to the [project security recommendation](https://github.com/vector-im/element-web/#important-security-note). But serve Element is very useful. Fully recommended if you have the posibility to destiny different domain names for Synapse and Element (`synapse_server_name` != `element_server_name`). Otherwise you can install both in the same domain name at your own risk (`synapse_server_name` == `element_server_name`).
 
+Since version 3.0.0, this role is compatible with [Element Web Chat version 1.7.15](https://github.com/vector-im/element-web/releases/tag/v1.7.15) and above. But is not compatible with Riot Web Chat (Versions 1.7.14 and olders).
+
 Deployment diagram
 ------------
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Through authentication providers it's possible to integrate decentralized logins
 
 Finally, this role also allows you to serve the [Element](https://app.element.io/) (formerly Riot) web application together with Synapse. This feature is disabled by default (`synapse_installation_with_element: false`) due to the [project security recommendation](https://github.com/vector-im/element-web/#important-security-note). But serve Element is very useful. Fully recommended if you have the posibility to destiny different domain names for Synapse and Element (`synapse_server_name` != `element_server_name`). Otherwise you can install both in the same domain name at your own risk (`synapse_server_name` == `element_server_name`).
 
-Since version 3.0.0, this role is compatible with [Element Web Chat version 1.7.15](https://github.com/vector-im/element-web/releases/tag/v1.7.15) and above. But is not compatible with Riot Web Chat (Versions 1.7.14 and olders).
+Since version 3.0.0, this role is compatible with [Element web app version 1.7.15](https://github.com/vector-im/element-web/releases/tag/v1.7.15) and above, but is not compatible with Riot/Element versions 1.7.14 and olders.
 
 Deployment diagram
 ------------
@@ -179,7 +179,7 @@ element_installation_path: /var/www/element
 # eg: element.my-organization.org
 element_server_name: "{{ synapse_server_name }}"
 # Look https://github.com/vector-im/element-web/releases to use the latest version
-element_version: '1.7.3'
+element_version: '1.7.15'
 element_jitsi_preferred_domain: jitsi.riot.im
 # Name to display for the server
 element_display_name: 'My Org Chat'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -120,7 +120,7 @@ element_installation_path: /var/www/element
 element_server_name: "{{ synapse_server_name }}"
 
 # Look https://github.com/vector-im/element-web/releases to use the latest version
-element_version: '1.7.3'
+element_version: '1.7.15'
 
 element_jitsi_preferred_domain: jitsi.riot.im
 

--- a/tasks/element_web.yml
+++ b/tasks/element_web.yml
@@ -13,7 +13,7 @@
 - name: Download and unpack Element Web
   unarchive:
     remote_src: yes
-    src: https://github.com/vector-im/element-web/releases/download/v{{ element_version }}/riot-v{{ element_version }}.tar.gz
+    src: https://github.com/vector-im/element-web/releases/download/v{{ element_version }}/element-v{{ element_version }}.tar.gz
     dest: "{{ element_installation_path }}"
     owner: root
     group: root
@@ -22,7 +22,7 @@
 - name: Set Element custom configuration
   template:
     src: var/www/element/config.json.j2
-    dest: "{{ element_installation_path }}/riot-v{{ element_version }}/config.json"
+    dest: "{{ element_installation_path }}/element-v{{ element_version }}/config.json"
     owner: root
     group: root
     mode: 0664
@@ -30,7 +30,7 @@
 - name: Set custom Element welcome page
   template:
     src: var/www/element/custom-welcome.html.j2
-    dest: "{{ element_installation_path }}/riot-v{{ element_version }}/custom-welcome.html"
+    dest: "{{ element_installation_path }}/element-v{{ element_version }}/custom-welcome.html"
     owner: root
     group: root
     mode: 0664

--- a/templates/etc/nginx/sites-available/element_web.j2
+++ b/templates/etc/nginx/sites-available/element_web.j2
@@ -13,7 +13,7 @@ server {
     listen [::]:443 ssl;
     server_name {{ element_server_name }};
 
-    root {{ element_installation_path }}/riot-v{{ element_version }};
+    root {{ element_installation_path }}/element-v{{ element_version }};
 
     access_log  /var/log/nginx/{{ element_server_name }}.access.log;
     error_log  /var/log/nginx/{{ element_server_name }}.error.log;

--- a/templates/etc/nginx/sites-available/reverse_proxy_and_element_web.j2
+++ b/templates/etc/nginx/sites-available/reverse_proxy_and_element_web.j2
@@ -13,7 +13,7 @@ server {
     listen [::]:443 ssl;
     server_name {{ synapse_server_fqdn }};
 
-    root {{ element_installation_path }}/riot-v{{ element_version }};
+    root {{ element_installation_path }}/element-v{{ element_version }};
 
     access_log  /var/log/nginx/{{ synapse_server_fqdn }}.access.log;
     error_log  /var/log/nginx/{{ synapse_server_fqdn }}.error.log;


### PR DESCRIPTION
Version 2.0.0 of the role is not able to install the web chat application from version 1.7.15. With these changes can install web chat since that version (but not older ones).