### PR TITLE
Added support for Debian Bullseye

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v3.1.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v3.1.0)
+
+* Small change on python package name and the role now support Debian Bullseye. The psycopg2 package name is inferred from the system to maintain backward compatibility with Stretch and Buster.
+
 ## [v3.0.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v3.0.0)
 
 * Version 2.0.0 of the role is not able to install Element web app from version 1.7.15. Since version 3.0.0, this role is compatible with [Element web app version 1.7.15](https://github.com/vector-im/element-web/releases/tag/v1.7.15) and above, but is not compatible with Riot/Element versions 1.7.14 and olders.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
     versions:
     - stretch
     - buster
+    - bullseye
 
   galaxy_tags:
     - communication

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -7,7 +7,7 @@
     name:
       - postgresql
       - libpq-dev
-      - python-psycopg2
+      - "{{ 'python-psycopg2' if(ansible_distribution_major_version is version('10', '<=')) else 'python3-psycopg2' }}"
     state: present
 
 - name: Ensure PostgreSQL service is started


### PR DESCRIPTION
With this little change the role perfectly supports Debian Bullseye. I put an instance into production with it.

I've been trying to get the molecule tests to work for a long time but still haven't gotten it. Following community experiences, I plan to migrate them to GitHub Actions soon.

Despite going over the CI/CD, I don't want to delay in incorporating these improvements (and others that are coming) to the upstream role. (It wouldn't be very DevOps to delay releases unnecessarily).