### PR TITLE
Reverse proxy improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v3.2.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v3.2.0)
+
+* Now the nginx reverse proxy settings are based on the [official Matrix Synapse documentation](https://matrix-org.github.io/synapse/latest/reverse_proxy.html). Additionally, the `synapse_enable_admin_endpoints` boolean variable was added to enable or disable publishing of admin API endpoints.
+
 ## [v3.1.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v3.1.0)
 
 * Small change on python package name and the role now support Debian Bullseye. The psycopg2 package name is inferred from the system to maintain backward compatibility with Stretch and Buster.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v3.1.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v3.1.0)
+
+* Small change on python package name and the role now support Debian Bullseye. The psycopg2 package name is inferred from the system to maintain backward compatibility with Stretch and Buster.
+
 ## [v3.0.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v3.0.0)
 
 * Version 2.0.0 of the role is not able to install Element web app from version 1.7.15. Since version 3.0.0, this role is compatible with [Element web app version 1.7.15](https://github.com/vector-im/element-web/releases/tag/v1.7.15) and above, but is not compatible with Riot/Element versions 1.7.14 and olders.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ synapse_report_stats: 'no'
 # The largest allowed upload size in bytes
 synapse_max_upload_size: 10M
 
+# Endpoints for administering your Synapse instance are placed under /_synapse/admin. These require
+# authentication through an access token of an admin user. However as access to these endpoints grants
+# the caller a lot of power, we do not recommend exposing them to the public internet without good reason.
+# See https://matrix-org.github.io/synapse/latest/reverse_proxy.html
+synapse_enable_admin_endpoints: false
+
 # Local sources to templates and configuration files, useful
 # for overwriting if you want to use your own templates in conf.d
 synapse_confd_templates_src: var/lib/matrix-synapse/conf.d

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,12 @@ synapse_report_stats: 'no'
 # The largest allowed upload size in bytes
 synapse_max_upload_size: 10M
 
+# Endpoints for administering your Synapse instance are placed under /_synapse/admin. These require
+# authentication through an access token of an admin user. However as access to these endpoints grants
+# the caller a lot of power, we do not recommend exposing them to the public internet without good reason.
+# See https://matrix-org.github.io/synapse/latest/reverse_proxy.html
+synapse_enable_admin_endpoints: false
+
 # Local sources to templates and configuration files, useful
 # for overwriting if you want to use your own templates in conf.d
 synapse_confd_templates_src: var/lib/matrix-synapse/conf.d

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,7 @@ galaxy_info:
     versions:
     - stretch
     - buster
+    - bullseye
 
   galaxy_tags:
     - communication

--- a/tasks/postgresql.yml
+++ b/tasks/postgresql.yml
@@ -7,7 +7,7 @@
     name:
       - postgresql
       - libpq-dev
-      - python-psycopg2
+      - "{{ 'python-psycopg2' if(ansible_distribution_major_version is version('10', '<=')) else 'python3-psycopg2' }}"
     state: present
 
 - name: Ensure PostgreSQL service is started

--- a/templates/etc/nginx/sites-available/element_web.j2
+++ b/templates/etc/nginx/sites-available/element_web.j2
@@ -18,9 +18,18 @@ server {
     access_log  /var/log/nginx/{{ element_server_name }}.access.log;
     error_log  /var/log/nginx/{{ element_server_name }}.error.log;
 
-    location /_matrix {
+    location ~* ^(\/_matrix|\/_synapse\/client{% if synapse_enable_admin_endpoints %}|\/_synapse\/admin{% endif %}) {
+        # note: do not add a path (even a single /) after the port in `proxy_pass`,
+        # otherwise nginx will canonicalise the URI and cause signature verification
+        # errors.
         proxy_pass http://localhost:8008;
         proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $host;
+
+        # Nginx by default only allows file uploads up to 1M in size
+        # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
+        client_max_body_size {{ synapse_max_upload_size }};
     }
 
     add_header Strict-Transport-Security "max-age=31536000";

--- a/templates/etc/nginx/sites-available/reverse_proxy.j2
+++ b/templates/etc/nginx/sites-available/reverse_proxy.j2
@@ -7,11 +7,18 @@ server {
     access_log  /var/log/nginx/{{ synapse_server_fqdn }}.access.log;
     error_log  /var/log/nginx/{{ synapse_server_fqdn }}.error.log;
 
-    client_max_body_size  {{ synapse_max_upload_size }};
-
-    location /_matrix {
+    location ~* ^(\/_matrix|\/_synapse\/client{% if synapse_enable_admin_endpoints %}|\/_synapse\/admin{% endif %}) {
+        # note: do not add a path (even a single /) after the port in `proxy_pass`,
+        # otherwise nginx will canonicalise the URI and cause signature verification
+        # errors.
         proxy_pass http://localhost:8008;
         proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $host;
+
+        # Nginx by default only allows file uploads up to 1M in size
+        # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
+        client_max_body_size {{ synapse_max_upload_size }};
     }
 
     ssl_certificate /etc/letsencrypt/live/{{ synapse_server_fqdn }}/fullchain.pem;
@@ -28,11 +35,18 @@ server {
     access_log  /var/log/nginx/{{ synapse_server_fqdn }}.federation.access.log;
     error_log  /var/log/nginx/{{ synapse_server_fqdn }}.federation.error.log;
 
-    client_max_body_size  {{ synapse_max_upload_size }};
-
-    location / {
+    location ~* ^(\/_matrix|\/_synapse\/client{% if synapse_enable_admin_endpoints %}|\/_synapse\/admin{% endif %}) {
+        # note: do not add a path (even a single /) after the port in `proxy_pass`,
+        # otherwise nginx will canonicalise the URI and cause signature verification
+        # errors.
         proxy_pass http://localhost:8008;
         proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $host;
+
+        # Nginx by default only allows file uploads up to 1M in size
+        # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
+        client_max_body_size {{ synapse_max_upload_size }};
     }
 
     ssl_certificate /etc/letsencrypt/live/{{ synapse_server_fqdn }}/fullchain.pem;

--- a/templates/etc/nginx/sites-available/reverse_proxy_and_element_web.j2
+++ b/templates/etc/nginx/sites-available/reverse_proxy_and_element_web.j2
@@ -18,11 +18,18 @@ server {
     access_log  /var/log/nginx/{{ synapse_server_fqdn }}.access.log;
     error_log  /var/log/nginx/{{ synapse_server_fqdn }}.error.log;
 
-    client_max_body_size  {{ synapse_max_upload_size }};
-
-    location /_matrix {
+    location ~* ^(\/_matrix|\/_synapse\/client{% if synapse_enable_admin_endpoints %}|\/_synapse\/admin{% endif %}) {
+        # note: do not add a path (even a single /) after the port in `proxy_pass`,
+        # otherwise nginx will canonicalise the URI and cause signature verification
+        # errors.
         proxy_pass http://localhost:8008;
         proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $host;
+
+        # Nginx by default only allows file uploads up to 1M in size
+        # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
+        client_max_body_size {{ synapse_max_upload_size }};
     }
 
     add_header Strict-Transport-Security "max-age=31536000";
@@ -40,11 +47,18 @@ server {
     access_log  /var/log/nginx/{{ synapse_server_fqdn }}.federation.access.log;
     error_log  /var/log/nginx/{{ synapse_server_fqdn }}.federation.error.log;
 
-    client_max_body_size  {{ synapse_max_upload_size }};
-
-    location / {
+    location ~* ^(\/_matrix|\/_synapse\/client{% if synapse_enable_admin_endpoints %}|\/_synapse\/admin{% endif %}) {
+        # note: do not add a path (even a single /) after the port in `proxy_pass`,
+        # otherwise nginx will canonicalise the URI and cause signature verification
+        # errors.
         proxy_pass http://localhost:8008;
         proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Host $host;
+
+        # Nginx by default only allows file uploads up to 1M in size
+        # Increase client_max_body_size to match max_upload_size defined in homeserver.yaml
+        client_max_body_size {{ synapse_max_upload_size }};
     }
 
     ssl_certificate /etc/letsencrypt/live/{{ synapse_server_fqdn }}/fullchain.pem;


### PR DESCRIPTION
In addition to what is proposed in #8, this PR incorporates improvements to the nginx reverse proxy configuration (following the [recommendations of the official documentation](https://matrix-org.github.io/synapse/latest/reverse_proxy.html)) and the possibility enabling and disabling the API admin endpoints from the role.