### PR TITLE
Option to use external mail servers instead of local Postfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [v3.3.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v3.3.0)
+
+* Now it is possible to configure an external mail server to send notifications. Postfix is kept as the default option but it is not installed and configured unnecessarily if it will not be used.
+
 ## [v3.2.0](https://github.com/UdelaRInterior/ansible-role-matrix-synapse/tree/v3.2.0)
 
 * Now the nginx reverse proxy settings are based on the [official Matrix Synapse documentation](https://matrix-org.github.io/synapse/latest/reverse_proxy.html). Additionally, the `synapse_enable_admin_endpoints` boolean variable was added to enable or disable publishing of admin API endpoints.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Also based on the recommendation, a Nginx reverse proxy and valid Let's Encrypt 
 
 As a database server, it is possible to use PostgreSQL (recommended for production environments) and SQLite (recommended for small or testing environments). The role default option is PostgreSQL, contemplating its installation and configuration.
 
-A simple Postfix installation makes it possible to send notifications, account recovery, etc. via email. With easily customizable templates through variables.
+A simple Postfix local installation or a external SMTP server makes it possible to send notifications, account recovery, etc. via email. With easily customizable templates through variables.
 
 Optionally this role allows provisioning a CoTURN installation to [enable VoIP relaying on your matrix homeserver with TURN](https://github.com/matrix-org/synapse/blob/master/docs/turn-howto.md).
 
@@ -142,8 +142,14 @@ synapse_psql_password: secret-password
 ### Email
 # If email is not configured, password reset, registration and notifications via email will be disabled.
 synapse_email_enable: true
+
+synapse_smtp_host: localhost
+synapse_smtp_port: 25
+# synapse_smtp_user: synapse
+# synapse_smtp_pass: secret
+
 synapse_email_hostname: "{{ synapse_server_fqdn }}"
-synapse_email_notif_from: "YourFriendlyhomeserver" # without spaces
+synapse_email_notif_from: "MyOrganization Matrix Homeserver <matrix@myorganization.com>"
 
 synapse_email_with_custom_templates: false
 # If true, remember use a customized version of the template conf.d/email.yaml.j2 to reference them

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,8 +67,14 @@ synapse_psql_password: secret-password
 
 # If email is not configured, password reset, registration and notifications via email will be disabled.
 synapse_email_enable: true
+
+synapse_smtp_host: localhost
+synapse_smtp_port: 25
+# synapse_smtp_user: synapse
+# synapse_smtp_pass: secret
+
 synapse_email_hostname: "{{ synapse_server_fqdn }}"
-synapse_email_notif_from: "YourFriendlyhomeserver" # without spaces
+synapse_email_notif_from: "MyOrganization Matrix Homeserver <matrix@myorganization.com>"
 
 synapse_email_with_custom_templates: false
 # If true, remember use a customized version of the template conf.d/email.yaml.j2 to reference them

--- a/tasks/email.yml
+++ b/tasks/email.yml
@@ -5,6 +5,7 @@
     apt:
       name: postfix
       state: present
+    when: synapse_smtp_host == 'localhost'
 
   - name: Configure postfix
     template:
@@ -14,6 +15,7 @@
       owner: root
       group: root
     notify: restart postfix
+    when: synapse_smtp_host == 'localhost'
 
   - name: Configure Synapse mailing
     template:

--- a/templates/var/lib/matrix-synapse/conf.d/email.yaml.j2
+++ b/templates/var/lib/matrix-synapse/conf.d/email.yaml.j2
@@ -8,10 +8,14 @@
 #
 email:
 #  enable_notifs: true
-  smtp_host: "localhost"
-  smtp_port: 25 # SSL: 465, STARTTLS: 587
-#   smtp_user: "exampleusername"
-#   smtp_pass: "examplepassword"
+  smtp_host: "{{ synapse_smtp_host | default('localhost') }}"
+  smtp_port: {{ synapse_smtp_port | default('25') }}  # SSL: 465, STARTTLS: 587
+{% if synapse_smtp_user is defined %}
+  smtp_user: "{{ synapse_smtp_user }}"
+{% endif %}
+{% if synapse_smtp_pass is defined %}
+  smtp_pass: "{{ synapse_smtp_pass }}"
+{% endif %}
 #   require_transport_security: false
   notif_from: "{{ synapse_email_notif_from }}"
 #   app_name: Matrix


### PR DESCRIPTION
This PR is the last pending improvement that I anticipated in #8.

With these changes it is possible to configure an external mail server to send notifications.

Postfix is kept as the default option, therefore the backward compatibility of the role is maintained, but now it's not installed and configured unnecessarily if it will not be used.