### PR TITLE
Move ansible-lint and yamllint outside of molecule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ before_script:
 
 script:
   # Run tests.
+  - yammlint .
+  - ansible-lint --offline .
   - molecule test --all
 
 notifications:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,11 +9,6 @@ dependency:
 driver:
   name: docker
 
-lint: |
-  set -e
-  yamllint .
-  ansible-lint
-
 platforms:
   - name: buster
     image: quay.io/paulfantom/molecule-systemd:debian-10
@@ -24,10 +19,6 @@ platforms:
 
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
 
 verifier:
   name: testinfra
-  lint:
-    name: flake8

--- a/molecule/full/molecule.yml
+++ b/molecule/full/molecule.yml
@@ -9,11 +9,6 @@ dependency:
 driver:
   name: docker
 
-lint: |
-  set -e
-  yamllint .
-  ansible-lint
-
 platforms:
   - name: buster
     image: quay.io/paulfantom/molecule-systemd:debian-10
@@ -24,10 +19,6 @@ platforms:
 
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
 
 verifier:
   name: testinfra
-  lint:
-    name: flake8


### PR DESCRIPTION
newer versions of molecule removed the lint step (allowing big project to run test in // without reruning linting).